### PR TITLE
docs: add minimal CLAUDE.md referencing root

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# chorbit-client
+
+Shared behavioral rules, workflow, and git conventions live in the root `CLAUDE.md` one directory up, at `chorbit/CLAUDE.md`.
+
+@../CLAUDE.md
+
+Repo-specific stack, commands, and gotchas live in `README.md`.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ npm run typecheck        # tsc --noEmit
 npm run lint             # ESLint
 ```
 
+## Git
+- Branch format: `{type}/{issue-number}-{short-slug}` — e.g. `feat/14-auth-form`, `fix/7-avatar-overflow`, `chore/8-eslint-setup`
+- Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`
+- Commit format: `type: description (#issue-number)`
+- Branch off `main`, merge back via PR — never merge directly
+
 ## Conventions
 - TypeScript strict, no `any`
 - Named exports only (no default exports)


### PR DESCRIPTION
Adds a thin `CLAUDE.md` at the repo root that imports the shared root file at `chorbit/CLAUDE.md`. Keeps all behavioral rules in one place while letting Claude Code pick them up when launched from inside this repo.

See also: Chorebit/chorbit-server#26

Closes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Git contribution guidelines covering branch naming conventions, commit message format, and pull request workflow requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->